### PR TITLE
Update deprecated Stan array syntax

### DIFF
--- a/inst/stan/ame_beta_binomial.stan
+++ b/inst/stan/ame_beta_binomial.stan
@@ -1,16 +1,16 @@
 data{
   int n_nodes ;
   int N ; 
-  int spAid[N] ;  
-  int spBid[N] ;  
+  array[N] int spAid ;  
+  array[N] int spBid ;  
   int Xdy_cols ; 
   int Xsp_cols ;  
   matrix[N,Xdy_cols] Xdy ; 
   matrix[N,Xsp_cols] XA ;  
   matrix[N,Xsp_cols] XB ;  
   int K ; 
-  int both[N] ; 
-  int either[N] ; 
+  array[N] int both ; 
+  array[N] int either ; 
   real<lower=0> prior_intercept_scale ;
   real<lower=0> prior_betas_scale ;
   real<lower=0> prior_sigma_addeff_rate ;

--- a/inst/stan/ame_binomial.stan
+++ b/inst/stan/ame_binomial.stan
@@ -1,16 +1,16 @@
 data{
   int n_nodes ;
   int N ; 
-  int spAid[N] ;  
-  int spBid[N] ;  
+  array[N] int spAid ;  
+  array[N] int spBid ;  
   int Xdy_cols ; 
   int Xsp_cols ;  
   matrix[N,Xdy_cols] Xdy ; 
   matrix[N,Xsp_cols] XA ;  
   matrix[N,Xsp_cols] XB ;  
   int K ; 
-  int both[N] ; 
-  int either[N] ; 
+  array[N] int both ; 
+  array[N] int either ; 
   real<lower=0> prior_intercept_scale ;
   real<lower=0> prior_betas_scale ;
   real<lower=0> prior_sigma_addeff_rate ;

--- a/inst/stan/ame_zi_binomial.stan
+++ b/inst/stan/ame_zi_binomial.stan
@@ -53,16 +53,16 @@ functions {
 data{
   int n_nodes ;
   int N ; 
-  int spAid[N] ;  
-  int spBid[N] ;  
+  array[N] int spAid ;  
+  array[N] int spBid ;  
   int Xdy_cols ; 
   int Xsp_cols ;  
   matrix[N,Xdy_cols] Xdy ; 
   matrix[N,Xsp_cols] XA ;  
   matrix[N,Xsp_cols] XB ;  
   int K ; 
-  int both[N] ; 
-  int either[N] ; 
+  array[N] int both ; 
+  array[N] int either ; 
   real<lower=0> prior_intercept_scale ;
   real<lower=0> prior_betas_scale ;
   real<lower=0> prior_sigma_addeff_rate ;

--- a/inst/stan/srm_beta_binomial.stan
+++ b/inst/stan/srm_beta_binomial.stan
@@ -1,15 +1,15 @@
 data{
   int n_nodes ;
   int N ; 
-  int spAid[N] ;  
-  int spBid[N] ;  
+  array[N] int spAid ;  
+  array[N] int spBid ;  
   int Xdy_cols ; 
   int Xsp_cols ;  
   matrix[N,Xdy_cols] Xdy ; 
   matrix[N,Xsp_cols] XA ;  
   matrix[N,Xsp_cols] XB ;  
-  int both[N] ; 
-  int either[N] ; 
+  array[N] int both ; 
+  array[N] int either ; 
   real<lower=0> prior_intercept_scale ;
   real<lower=0> prior_betas_scale ;
   real<lower=0> prior_sigma_addeff_rate ;

--- a/inst/stan/srm_binomial.stan
+++ b/inst/stan/srm_binomial.stan
@@ -1,15 +1,15 @@
 data{
   int n_nodes ;
   int N ; 
-  int spAid[N] ;  
-  int spBid[N] ;  
+  array[N] int spAid ;  
+  array[N] int spBid ;  
   int Xdy_cols ; 
   int Xsp_cols ;  
   matrix[N,Xdy_cols] Xdy ; 
   matrix[N,Xsp_cols] XA ;  
   matrix[N,Xsp_cols] XB ;  
-  int both[N] ; 
-  int either[N] ; 
+  array[N] int both ; 
+  array[N] int either ; 
   real<lower=0> prior_intercept_scale ;
   real<lower=0> prior_betas_scale ;
   real<lower=0> prior_sigma_addeff_rate ;

--- a/inst/stan/srm_zi_binomial.stan
+++ b/inst/stan/srm_zi_binomial.stan
@@ -53,15 +53,15 @@ functions {
 data{
   int n_nodes ;
   int N ; 
-  int spAid[N] ;  
-  int spBid[N] ;  
+  array[N] int spAid ;  
+  array[N] int spBid ;  
   int Xdy_cols ; 
   int Xsp_cols ;  
   matrix[N,Xdy_cols] Xdy ; 
   matrix[N,Xsp_cols] XA ;  
   matrix[N,Xsp_cols] XB ;  
-  int both[N] ; 
-  int either[N] ; 
+  array[N] int both ; 
+  array[N] int either ; 
   real<lower=0> prior_intercept_scale ;
   real<lower=0> prior_betas_scale ;
   real<lower=0> prior_sigma_addeff_rate ;


### PR DESCRIPTION
This PR updates your package's Stan models to use the new `array` syntax, otherwise it will fail to install with the next version of `rstan`